### PR TITLE
added fix command from the oxid console project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-.idea
+/.idea
+/composer.phar
+/vendor

--- a/Command/ModuleFixCommand.php
+++ b/Command/ModuleFixCommand.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace OxidCommunity\ModuleInternals\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Output\NullOutput;
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\Module\Module;
+use OxidEsales\Eshop\Core\Module\ModuleList;
+use OxidEsales\Eshop\Core\Exception\InputException;
+use OxidCommunity\ModuleInternals\Core\ModuleStateFixer;
+use OxidProfessionalServices\OxidConsole\Core\ShopConfig;
+
+/**
+ * Fix States command
+ */
+class ModuleFixCommand extends Command
+{
+
+    /**
+     * @var array|null Available module ids
+     */
+    protected $_aAvailableModuleIds = null;
+
+    /** @var InputInterface */
+    private $input;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure()
+    {
+        $this
+            ->setName('module:fix')
+            ->setAliases(['fix:states'])
+            ->setDescription('Fixes modules metadata states')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Includes all modules')
+            ->addOption('base-shop', 'b', InputOption::VALUE_NONE, 'Apply changes to base shop only')
+            ->addOption('shop', 's', InputOption::VALUE_REQUIRED, 'Apply changes to given shop only')
+            ->addArgument('module-id', InputArgument::IS_ARRAY, 'Module id/ids to use');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->input = $input;
+
+        $verboseOutput = $output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE
+            ? $output
+            : new NullOutput();
+
+        try {
+            $aModuleIds = $this->_parseModuleIds();
+            $aShopConfigs = $this->_parseShopConfigs();
+        } catch (InputException $oEx) {
+            $output->writeLn($oEx->getMessage());
+            exit(1);
+        }
+
+        /** @var ModuleStateFixer $oModuleStateFixer */
+        $oModuleStateFixer = Registry::get(ModuleStateFixer::class);
+        $oModuleStateFixer->setOutput($output);
+        $oModuleStateFixer->setDebugOutput($verboseOutput);
+
+        /** @var Module $oModule */
+        $oModule = oxNew(Module::class);
+
+        foreach ($aShopConfigs as $oConfig) {
+            $moduleCount = count($aModuleIds);
+            $verboseOutput->writeLn('[DEBUG] Working on shop id ' . $oConfig->getShopId() . " fixing $moduleCount modules");
+
+            foreach ($aModuleIds as $sModuleId) {
+                $oModule->setMetaDataVersion(null);
+                if (!$oModule->load($sModuleId)) {
+                    $verboseOutput->writeLn("[DEBUG] {$sModuleId} does not exist - skipping");
+                    continue;
+                }
+
+                $verboseOutput->writeLn("[DEBUG] Fixing {$sModuleId} module");
+                $oModuleStateFixer->fix($oModule, $oConfig);
+            }
+
+            $verboseOutput->writeLn('');
+        }
+
+        $output->writeLn('Fixed module states successfully');
+    }
+
+    /**
+     * Parse and return module ids from input
+     *
+     * @return array
+     *
+     * @throws InputException
+     */
+    protected function _parseModuleIds()
+    {
+        if ($this->input->getOption('all')) {
+            return $this->_getAvailableModuleIds();
+        }
+
+        if (count($this->input->getArguments()['module-id']) === 0) {
+            throw oxNew(
+                InputException::class,
+                'Please specify at least one module if as argument or use --all (-a) option'
+            );
+        }
+
+        $requestedModuleIds = $this->input->getArguments()['module-id'];
+        $availableModuleIds = $this->_getAvailableModuleIds();
+
+        // Checking if all provided module ids exist
+        foreach ($requestedModuleIds as $moduleId) {
+            if (!in_array($moduleId, $availableModuleIds)) {
+                throw oxNew(
+                    InputException::class,
+                    "{$moduleId} module does not exist"
+                );
+            }
+        }
+
+        return $requestedModuleIds;
+    }
+
+    /**
+     * Parse and return shop config objects from input
+     *
+     * @return ShopConfig[]
+     *
+     * @throws InputException
+     */
+    protected function _parseShopConfigs()
+    {
+        if ($this->input->getOption('base-shop')) {
+            return array(Registry::getConfig());
+        }
+
+        if ($shopId = $this->input->getOption('shop')) {
+            if ($oConfig = ShopConfig::get($shopId)) {
+                return array($oConfig);
+            }
+
+            throw oxNew(
+                InputException::class,
+                'Shop id does not exist'
+            );
+        }
+
+        return ShopConfig::getAll();
+    }
+
+    /**
+     * Get all available module ids
+     *
+     * @return array
+     */
+    protected function _getAvailableModuleIds()
+    {
+        if ($this->_aAvailableModuleIds === null) {
+            $oConfig = Registry::getConfig();
+
+            // We are calling getModulesFromDir() because we want to refresh
+            // the list of available modules. This is a workaround for OXID
+            // bug.
+            oxNew(ModuleList::class)->getModulesFromDir($oConfig->getModulesDir());
+            $this->_aAvailableModuleIds = array_keys($oConfig->getConfigParam('aModulePaths'));
+        }
+
+        return $this->_aAvailableModuleIds;
+    }
+}

--- a/Core/InternalModule.php
+++ b/Core/InternalModule.php
@@ -14,6 +14,7 @@ namespace OxidCommunity\ModuleInternals\Core;
 use \OxidEsales\Eshop\Core\DatabaseProvider as DatabaseProvider;
 use \OxidEsales\Eshop\Core\Registry as Registry;
 use \OxidEsales\Eshop\Core\Module\ModuleList as ModuleList;
+use OxidEsales\Eshop\Core\Request;
 
 /**
  * Class InternalModule: chain extends OxidEsales\Eshop\Core\Module\Module
@@ -190,11 +191,14 @@ class InternalModule extends InternalModule_parent
             return $this->checked;
         }
         $title = parent::getTitle();
-        $this->checkState();
-        if (! $this->stateFine) {
-            $title .= ' <strong style="color: #900">Issue found!</strong>';
+        $cl = Registry::getRequest()->getRequestParameter('cl');
+        if ($cl == 'module_list') {
+            $this->checkState();
+            if (!$this->stateFine) {
+                $title .= ' <strong style="color: #900">Issue found!</strong>';
+            }
+            $this->checked = $title;
         }
-        $this->checked = $title;
         return $title;
     }
 
@@ -489,8 +493,9 @@ class InternalModule extends InternalModule_parent
      */
     public function checkModuleController()
     {
-        $aMetadataFiles = $this->getInfo('controllers');
-        $aDatabaseFiles = $this->getModuleEntries(ModuleList::MODULE_KEY_CONTROLLERS);
+        $aMetadataFiles = $this->getControllers();
+        $oModuleStateFixer = Registry::get(ModuleStateFixer::class);
+        $aDatabaseFiles =  $oModuleStateFixer->getModuleControllerEntries($this->getId());
 
         return $this->checkModuleFileConsistency($aMetadataFiles, $aDatabaseFiles);
     }

--- a/Core/ModuleExtensionCleanerDebug.php
+++ b/Core/ModuleExtensionCleanerDebug.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: keywan
+ * Date: 23.11.18
+ * Time: 11:37
+ */
+
+namespace OxidCommunity\ModuleInternals\Core;
+
+
+use OxidEsales\Eshop\Core\Module\ModuleExtensionsCleaner;
+use OxidEsales\Eshop\Core\Registry;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ModuleExtensionCleanerDebug extends ModuleExtensionsCleaner
+{
+    protected $_debugOutput;
+
+    public function __construct()
+    {
+        $this->_debugOutput= new NullOutput();
+    }
+
+    public function setOutput(OutputInterface $out){
+
+        $this->_debugOutput = $out;
+    }
+
+    /**
+     * Removes garbage ( module not used extensions ) from all installed extensions list.
+     * For example: some classes were renamed, so these should be removed.
+     *
+     * @param array                                $installedExtensions
+     * @param \OxidEsales\Eshop\Core\Module\Module $module
+     *
+     * @return array
+     */
+    public function cleanExtensions($installedExtensions, \OxidEsales\Eshop\Core\Module\Module $module)
+    {
+        $installedExtensions = parent::cleanExtensions($installedExtensions, $module);
+
+        $oModules = oxNew( \OxidEsales\EshopCommunity\Core\Module\ModuleList::class );
+        //ids will include garbage in case there are files that not registered by any module
+        $ids = $oModules->getModuleIds();
+
+        $config = Registry::getConfig();
+        $knownIds = array_keys($config->getConfigParam('aModulePaths'));
+        $diff = array_diff($ids,$knownIds);
+        if ($diff) {
+            foreach ($diff as $item) {
+                foreach ($installedExtensions as &$coreClassExtension) {
+                    foreach ($coreClassExtension as $i => $ext) {
+                        if ($ext === $item) {
+                            $this->_debugOutput->writeln("$item will be removed");
+                            unset($coreClassExtension[$i]);
+                        }
+                    }
+                }
+            }
+        }
+
+        return $installedExtensions;
+    }
+
+    protected function removeGarbage($aInstalledExtensions, $aarGarbage)
+    {
+        foreach ($aarGarbage as $moduleId => $aExt) {
+            $this->_debugOutput->writeLn("[INFO] removing garbage for module $moduleId: " . join(',', $aExt));
+        }
+        return parent::removeGarbage($aInstalledExtensions, $aarGarbage);
+    }
+
+    /**
+     * Returns extension which is no longer in metadata - garbage
+     *
+     * @param array $moduleMetaDataExtensions  extensions defined in metadata.
+     * @param array $moduleInstalledExtensions extensions which are installed
+     *
+     * @return array
+     */
+    protected function getModuleExtensionsGarbage($moduleMetaDataExtensions, $moduleInstalledExtensions)
+    {
+
+        $garbage = parent::getModuleExtensionsGarbage($moduleMetaDataExtensions, $moduleInstalledExtensions);
+
+        foreach ($moduleInstalledExtensions as $coreClassName => $listOfExtensions) {
+            foreach ($listOfExtensions as $extensions) {
+                if (! (isset($moduleMetaDataExtensions[$coreClassName]) && $moduleMetaDataExtensions[$coreClassName] == $extensions)) {
+                    $garbage[$coreClassName][] = $extensions;
+                }
+            }
+        }
+
+        return $garbage;
+    }
+
+    /**
+     * Returns extensions list by module id.
+     *
+     * @param array  $modules  Module array (nested format)
+     * @param string $moduleId Module id/folder name
+     *
+     * @return array
+     */
+    protected function filterExtensionsByModuleId($modules, $moduleId)
+    {
+        $modulePaths = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aModulePaths');
+
+        $path = '';
+        if (isset($modulePaths[$moduleId])) {
+            $path = $modulePaths[$moduleId] . '/';
+        }
+
+        // TODO: This condition should be removed. Need to check integration tests.
+        if (!$path) {
+            $path = $moduleId . "/";
+        }
+
+        $filteredModules = [];
+        foreach ($modules as $class => $extend) {
+            foreach ($extend as $extendPath) {
+                if (strpos($extendPath, $path) === 0) {
+                    $filteredModules[$class][] = $extendPath;
+                }
+            }
+        }
+
+        return $filteredModules;
+    }
+}

--- a/Core/ModuleStateFixer.php
+++ b/Core/ModuleStateFixer.php
@@ -1,0 +1,523 @@
+<?php
+
+namespace OxidCommunity\ModuleInternals\Core;
+
+use OxidEsales\Eshop\Core\Config;
+use OxidEsales\Eshop\Core\DatabaseProvider;
+use OxidEsales\Eshop\Core\Registry;
+use OxidEsales\Eshop\Core\SettingsHandler;
+use OxidEsales\Eshop\Core\Module\Module;
+use OxidEsales\Eshop\Core\Module\ModuleInstaller;
+use OxidEsales\Eshop\Core\Module\ModuleCache;
+use OxidEsales\Eshop\Core\Exception\ModuleValidationException;
+use OxidProfessionalServices\OxidConsole\Core\Module\ModuleExtensionCleanerDebug;
+use Symfony\Component\Console\Output\OutputInterface;
+use OxidEsales\Eshop\Core\Module\ModuleVariablesLocator;
+/**
+ * Module state fixer
+ */
+class ModuleStateFixer extends ModuleInstaller
+{
+
+    public function __construct($cache = null, $cleaner = null){
+        $cleaner = oxNew(ModuleExtensionCleanerDebug::class);
+        parent::__construct($cache, $cleaner);
+    }
+
+
+
+    /** @var OutputInterface $_debugOutput */
+    protected $_debugOutput;
+
+    /** @var OutputInterface $_debugOutput */
+    protected $output;
+
+    protected $needCacheClear = false;
+    protected $initialCacheClearDone = false;
+    /**
+     * @var null|Module $module
+     */
+    protected $module = null;
+
+    /**
+     * Fix module states task runs version, extend, files, templates, blocks,
+     * settings and events information fix tasks
+     *
+     * @param Module      $module
+     * @param Config|null $oConfig If not passed uses default base shop config
+     */
+    public function fix($module, $oConfig = null)
+    {
+        if ($oConfig !== null) {
+            $this->setConfig($oConfig);
+        }
+
+        $moduleId = $module->getId();
+
+        if (!$this->initialCacheClearDone) {
+            //clearing some cache to be sure that fix runs not against a stale cache
+            ModuleVariablesLocator::resetModuleVariables();
+            if (extension_loaded('apc') && ini_get('apc.enabled')) {
+                apc_clear_cache();
+            }
+            if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_VERBOSE) {
+                $this->output->writeln("initial cache cleared");
+            }
+            $this->initialCacheClearDone = true;
+        }
+        $this->module = $module;
+        $this->needCacheClear = false;
+        $this->restoreModuleInformation($module, $moduleId);
+        if ($this->needCacheClear){
+            $this->resetModuleCache($module);
+            $this->output->writeln("cache cleared for $moduleId");
+        }
+    }
+
+
+    //public function resetModuleCache($module = null){
+    //  parent::resetCache()
+    //}
+
+
+    /**
+     * Add module template files to config for smarty.
+     *
+     * @param array  $aModuleTemplates Module templates array
+     * @param string $sModuleId        Module id
+     */
+    protected function _addTemplateFiles($aModuleTemplates, $sModuleId)
+    {
+        $aTemplates = (array) $this->getConfig()->getConfigParam('aModuleTemplates');
+        $old = isset($aTemplates[$sModuleId]) ? $aTemplates[$sModuleId] : null;
+        if (is_array($aModuleTemplates)) {
+            $diff = $this->diff($old,$aModuleTemplates);
+            if ($diff) {
+                $this->output->writeLn("$sModuleId fixing templates:"  . $old === null ? ' everything ' :  var_export($diff, true));
+                $aTemplates[$sModuleId] = $aModuleTemplates;
+                $this->_saveToConfig('aModuleTemplates', $aTemplates);
+                $this->needCacheClear = true;
+            }
+        } else {
+            if ($old) {
+                $this->output->writeLn("$sModuleId unregister templates:");
+                $this->_deleteTemplateFiles($sModuleId);
+                $this->needCacheClear = true;
+            }
+        }
+    }
+
+
+    /**
+     * Add module files to config for auto loader.
+     *
+     * @param array  $aModuleFiles Module files array
+     * @param string $sModuleId    Module id
+     */
+    protected function _addModuleFiles($aModuleFiles, $sModuleId)
+    {
+        $aFiles = (array) $this->getConfig()->getConfigParam('aModuleFiles');
+
+        $old =  isset($aFiles[$sModuleId]) ? $aFiles[$sModuleId] : null;
+        if ($aModuleFiles !== null) {
+            $aModuleFiles = array_change_key_case($aModuleFiles, CASE_LOWER);
+        }
+
+        if (is_array($aModuleFiles)) {
+            $diff = $this->diff($old,$aModuleFiles);
+            if ($diff) {
+                $this->output->writeLn("$sModuleId fixing files:" . $old === null ? ' everything' : var_export($diff, true));
+                $aFiles[$sModuleId] = $aModuleFiles;
+                $this->_saveToConfig('aModuleFiles', $aFiles);
+                $this->needCacheClear = true;
+            }
+        } else {
+            if ($old) {
+                $this->output->writeLn("$sModuleId unregister files");
+                $this->_deleteModuleFiles($sModuleId);
+                $this->needCacheClear = true;
+            }
+        }
+
+    }
+
+
+    /**
+     * Add module events to config.
+     *
+     * @param array  $aModuleEvents Module events
+     * @param string $sModuleId     Module id
+     */
+    protected function _addModuleEvents($aModuleEvents, $sModuleId)
+    {
+        $aEvents = (array) $this->getConfig()->getConfigParam('aModuleEvents');
+        $old =  isset($aEvents[$sModuleId]) ? $aEvents[$sModuleId] : null;
+        if (is_array($aModuleEvents) && count($aModuleEvents)) {
+            $diff = $this->diff($old,$aModuleEvents);
+            if ($diff) {
+                $aEvents[$sModuleId] = $aModuleEvents;
+                $this->output->writeLn("$sModuleId fixing module events:" . $old == null ? ' everything ' : var_export($diff, true));
+                $this->_saveToConfig('aModuleEvents', $aEvents);
+                $this->needCacheClear = true;
+            }
+        } else {
+            if ($old) {
+                $this->output->writeLn("$sModuleId unregister events");
+                $this->_deleteModuleEvents($sModuleId);
+                $this->needCacheClear = true;
+            }
+        }
+
+    }
+
+    /**
+     * Add module id with extensions to config.
+     *
+     * @param array  $moduleExtensions Module version
+     * @param string $moduleId         Module id
+     */
+    protected function _addModuleExtensions($moduleExtensions, $moduleId)
+    {
+        $extensions = (array) $this->getConfig()->getConfigParam('aModuleExtensions');
+        $old = isset($extensions[$moduleId]) ? $extensions[$moduleId] : null;
+        $old = (array) $old;
+        $new = $moduleExtensions === null ? [] : array_values($moduleExtensions);
+        if (is_array($moduleExtensions)) {
+            $diff = $this->diff($old, $new);
+            if ($diff) {
+                $extensions[$moduleId] = array_values($moduleExtensions);
+                $this->output->writeLn("$moduleId fixing module extensions:" . $old === null ? ' everything ' : var_export($diff, true));
+                $this->_saveToConfig('aModuleExtensions', $extensions);
+                $this->needCacheClear = true;
+            }
+        } else {
+            $this->output->writeLn("$moduleId unregister module extensions");
+            $this->needCacheClear = true;
+            $this->_saveToConfig('aModuleExtensions', []);
+        }
+    }
+
+    /**
+     * Add module version to config.
+     *
+     * @param string $sModuleVersion Module version
+     * @param string $sModuleId      Module id
+     */
+    protected function _addModuleVersion($sModuleVersion, $sModuleId)
+    {
+        $aVersions = (array) $this->getConfig()->getConfigParam('aModuleVersions');
+        $old =  isset($aVersions[$sModuleId]) ? $aVersions[$sModuleId] : '';
+        if (is_array($aVersions)) {
+            $aVersions[$sModuleId] = $sModuleVersion;
+            if ($old !== $sModuleVersion) {
+                $this->output->writeLn("$sModuleId fixing module version from $old to $sModuleVersion");
+                $aEvents[$sModuleId] = $sModuleVersion;
+                $this->_saveToConfig('aModuleVersions', $aVersions);
+                $this->needCacheClear = true;
+            }
+        } else {
+            if ($old) {
+                $this->output->writeLn("$sModuleId unregister module version");
+                $this->_deleteModuleVersions($sModuleId);
+                $this->needCacheClear = true;
+            }
+        }
+
+    }
+
+    /**
+     * compares 2 assoc arrays
+     * true if there is something changed
+     * @param $array1
+     * @param $array2
+     * @return bool
+     */
+    protected function diff($array1,$array2){
+        if ($array1 === null) {
+            if ($array2 === null) {
+                return false; //indicate no diff
+            }
+            return $array2; //full array2 is new
+        }
+        if ($array2 === null) {
+            //indicate that diff is there  (so return a true value) but everthing should be droped
+            return 'null';
+        }
+        $diff = array_merge(array_diff_assoc($array1,$array2),array_diff_assoc($array2,$array1));
+        return $diff;
+    }
+
+
+    /**
+     * Code taken from OxidEsales\EshopCommunity\Core\Module::activate
+     *
+     * @param Module $module
+     * @param string $moduleId
+     *
+     * @throws \OxidEsales\Eshop\Core\Exception\StandardException
+     */
+    private function restoreModuleInformation($module, $moduleId)
+    {
+        $this->_addExtensions($module);
+        $metaDataVersion = $module->getMetaDataVersion();
+        $metaDataVersion = $metaDataVersion == '' ? $metaDataVersion = "1.0" : $metaDataVersion;
+        if (version_compare($metaDataVersion, '2.0', '<')) {
+            $this->_addModuleFiles($module->getInfo("files"), $moduleId);
+        }
+        $this->_addTemplateBlocks($module->getInfo("blocks"), $moduleId);
+        $this->_addTemplateFiles($module->getInfo("templates"), $moduleId);
+        $this->_addModuleSettings($module->getInfo("settings"), $moduleId);
+        $this->_addModuleVersion($module->getInfo("version"), $moduleId);
+        $this->_addModuleExtensions($module->getExtensions(), $moduleId);
+        $this->_addModuleEvents($module->getInfo("events"), $moduleId);
+
+        if (version_compare($metaDataVersion, '2.0', '>=')) {
+            try {
+                $this->setModuleControllers($module->getControllers(), $moduleId, $module);
+            } catch (ModuleValidationException $exception) {
+                print "[ERROR]: duplicate controllers:" . $exception->getMessage() ."\n";
+            }
+        }
+    }
+
+    /**
+     * Get config tables specific module id
+     *
+     * @param string $moduleId
+     * @return string
+     */
+    protected function getModuleConfigId($moduleId)
+    {
+        return 'module:' . $moduleId;
+    }
+
+    /**
+     * Adds settings to database.
+     *
+     * @param array  $moduleSettings Module settings array
+     * @param string $moduleId       Module id
+     */
+    protected function _addModuleSettings($moduleSettings, $moduleId)
+    {
+        $config = $this->getConfig();
+        $shopId = $config->getShopId();
+        if (is_array($moduleSettings)) {
+            foreach ($moduleSettings as $setting) {
+
+                $module = $this->getModuleConfigId($moduleId);
+                $name = $setting["name"];
+                $type = $setting["type"];
+
+                $value = is_null($config->getConfigParam($name)) ? $setting["value"] : $config->getConfigParam($name);
+
+                $changed = $config->saveShopConfVar($type, $name, $value, $shopId, $module);
+                if ($changed) {
+                    $this->output->writeln("$moduleId: setting for '$name' fixed'");
+                    $this->needCacheClear = $this->needCacheClear || $changed;
+                }
+            }
+        }
+    }
+
+
+    /**
+     * Add controllers map for a given module Id to config
+     *
+     * @param array  $moduleControllers Map of controller ids and class names
+     * @param string $moduleId          The Id of the module
+     */
+    protected function setModuleControllers($moduleControllers, $moduleId, $module)
+    {
+        $classProviderStorage = $this->getClassProviderStorage();
+        $dbMap = $classProviderStorage->get();
+
+        $controllersForThatModuleInDb = isset($dbMap[$moduleId]) ? $dbMap[$moduleId] : [];
+
+        $duplicatedKeys = array_intersect_key(array_change_key_case($moduleControllers, CASE_LOWER), $controllersForThatModuleInDb);
+
+        if (array_diff_assoc($moduleControllers,$duplicatedKeys)) {
+            $this->output->writeLn("$moduleId fix module ModuleControllers");
+            $this->deleteModuleControllers($moduleId);
+            $this->resetModuleCache($module);
+            $this->validateModuleMetadataControllersOnActivation($moduleControllers);
+
+            $classProviderStorage = $this->getClassProviderStorage();
+
+            $classProviderStorage->add($moduleId, $moduleControllers);
+            $this->needCacheClear = true;
+        }
+
+    }
+
+
+    /**
+     * Reset module cache
+     *
+     * @param Module $module
+     */
+    private function resetModuleCache($module)
+    {
+        $moduleCache = oxNew(ModuleCache::class, $module);
+        $moduleCache->resetCache();
+    }
+
+    /**
+     * @param $o OutputInterface
+     */
+    public function setDebugOutput($o)
+    {
+        $this->_debugOutput = $o;
+    }
+
+    /**
+     * @param $o OutputInterface
+     */
+    public function setOutput($o)
+    {
+        $this->output = $o;
+        $this->getModuleCleaner()->setOutput($o);
+    }
+
+
+    /**
+     * Add extension to module
+     *
+     * @param \OxidEsales\Eshop\Core\Module\Module $module
+     */
+    protected function _addExtensions(\OxidEsales\Eshop\Core\Module\Module $module)
+    {
+        $aModulesDefault = $this->getConfig()->getConfigParam('aModules');
+        $aModules = $this->getModulesWithExtendedClass();
+        $aModules = $this->_removeNotUsedExtensions($aModules, $module);
+
+
+        if ($module->hasExtendClass()) {
+            $this->validateMetadataExtendSection($module);
+            $aAddModules = $module->getExtensions();
+            $aModules = $this->_mergeModuleArrays($aModules, $aAddModules);
+        }
+
+        $aModules = $this->buildModuleChains($aModules);
+        if ($aModulesDefault != $aModules) {
+            $this->needCacheClear = true;
+            $onlyInAfterFix = array_diff($aModules, $aModulesDefault);
+            $onlyInBeforeFix = array_diff($aModulesDefault, $aModules);
+            $this->output->writeLn("[INFO] fixing " . $module->getId());
+            foreach ($onlyInAfterFix as $core => $ext) {
+                if ($oldChain = $onlyInBeforeFix[$core]) {
+                    $newExt = substr($ext, strlen($oldChain));
+                    if (!$newExt) {
+                        //$newExt = substr($ext, strlen($oldChain));
+                        $this->output->writeLn("[INFO] remove ext for $core");
+                        $this->output->writeLn("[INFO] old: $oldChain");
+                        $this->output->writeLn("[INFO] new: $ext");
+                        //$this->_debugOutput->writeLn("[ERROR] extension chain is corrupted for this module");
+                        //return;
+                        continue;
+                    } else {
+                        $this->output->writeLn("[INFO] append $core => ...$newExt");
+                    }
+                    unset($onlyInBeforeFix[$core]);
+                } else {
+                    $this->output->writeLn("[INFO] add $core => $ext");
+                }
+            }
+            foreach ($onlyInBeforeFix as $core => $ext) {
+                $this->output->writeLn("[INFO] remove $core => $ext");
+            }
+            $this->_saveToConfig('aModules', $aModules);
+        }
+    }
+
+
+
+    /**
+     * Add module templates to database.
+     *
+     * @deprecated please use setTemplateBlocks this method will be removed because
+     * the combination of deleting and adding does unnessery writes and so it does not scale
+     * also it's more likely to get race conditions (in the moment the blocks are deleted)
+     *
+     * @param array  $moduleBlocks Module blocks array
+     * @param string $moduleId     Module id
+     */
+    protected function _addTemplateBlocks($moduleBlocks, $moduleId)
+    {
+        /*
+        $shopid = $this->getConfig()->getShopId();
+        $moduleBlocksInDb = \OxidEsales\Eshop\Core\DatabaseProvider::getDb(DatabaseProvider::FETCH_MODE_ASSOC)->getAll("SELECT `OXPOS` as `position`,`OXTHEME` as theme, `OXTEMPLATE` as template, `OXBLOCKNAME` as block, `OXFILE` as file FROM oxtplblocks WHERE oxmodule = '$moduleId' AND oxshopid = '$shopid' AND `OXACTIVE` = 1 order by `OXPOS`");
+        check and set $this->needCacheClear = true;
+        */
+
+        $this->setTemplateBlocks($moduleBlocks, $moduleId);
+    }
+
+    /**
+     * Set module templates in the database.
+     * we do not use delete and add combination because
+     * the combination of deleting and adding does unnessery writes and so it does not scale
+     * also it's more likely to get race conditions (in the moment the blocks are deleted)
+     * @todo extract oxtplblocks query to ModuleTemplateBlockRepository
+     *
+     * @param array  $moduleBlocks Module blocks array
+     * @param string $moduleId     Module id
+     */
+    protected function setTemplateBlocks($moduleBlocks, $moduleId)
+    {
+        if (!is_array($moduleBlocks)) {
+            $moduleBlocks = array();
+        }
+        $shopId = $this->getConfig()->getShopId();
+        $db = \OxidEsales\Eshop\Core\DatabaseProvider::getDb();
+        $knownBlocks = ['dummy']; // Start with a dummy value to prevent having an empty list in the NOT IN statement.
+        $rowsEffected = 0;
+        foreach ($moduleBlocks as $moduleBlock) {
+            $blockId = md5($moduleId . json_encode($moduleBlock) . $shopId);
+            $knownBlocks[] = $blockId;
+
+            $template = $moduleBlock["template"];
+            $position = isset($moduleBlock['position']) && is_numeric($moduleBlock['position']) ?
+                intval($moduleBlock['position']) : 1;
+
+            $block = $moduleBlock["block"];
+            $filePath = $moduleBlock["file"];
+            $theme = isset($moduleBlock['theme']) ? $moduleBlock['theme'] : '';
+
+            $sql = "INSERT INTO `oxtplblocks` (`OXID`, `OXACTIVE`, `OXSHOPID`, `OXTHEME`, `OXTEMPLATE`, `OXBLOCKNAME`, `OXPOS`, `OXFILE`, `OXMODULE`)
+                     VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?)
+                     ON DUPLICATE KEY UPDATE
+                      `OXID` = VALUES(OXID),
+                      `OXACTIVE` = VALUES(OXACTIVE),
+                      `OXSHOPID` = VALUES(OXSHOPID),
+                      `OXTHEME` = VALUES(OXTHEME),
+                      `OXTEMPLATE` = VALUES(OXTEMPLATE),
+                      `OXBLOCKNAME` = VALUES(OXBLOCKNAME),
+                      `OXPOS` = VALUES(OXPOS),
+                      `OXFILE` = VALUES(OXFILE),
+                      `OXMODULE` = VALUES(OXMODULE)";
+
+            $rowsEffected += $db->execute($sql, array(
+                $blockId,
+                $shopId,
+                $theme,
+                $template,
+                $block,
+                $position,
+                $filePath,
+                $moduleId
+            ));
+        }
+
+        $listOfKnownBlocks = join(',', $db->quoteArray($knownBlocks));
+        $deleteblocks = "DELETE FROM oxtplblocks WHERE OXSHOPID = ? AND OXMODULE = ? AND OXID NOT IN ({$listOfKnownBlocks});";
+
+        $rowsEffected += $db->execute(
+            $deleteblocks,
+            array($shopId, $moduleId)
+        );
+
+        if ($rowsEffected) {
+            $this->needCacheClear = true;
+        }
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "oxid-community/moduleinternals",
   "description": "Display module internals",
   "type": "oxideshop-module",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "keywords": [
     "oxid",
     "modules",
@@ -13,9 +13,15 @@
   "license": [
     "GPL-3.0"
   ],
+  "require":{
+    "symfony/console" : "^2.7",
+    "composer/composer" : "^1.6",
+    "oxid-esales/oxideshop-ce" : "^6.0"
+  },
   "extra": {
     "oxideshop": {
-      "target-directory": "oxcom/moduleinternals"
+      "target-directory": "oxcom/moduleinternals",
+      "console-commands" : ["OxidCommunity\\ModuleInternals\\Command\\ModuleFixCommand"]
     }
   },
   "autoload": {


### PR DESCRIPTION
Adding command to oxid console for fixing module state.
This is useful during the deployment or for automated tasks.

The code for that command is extracted from the oxid console (https://github.com/OXIDprojects/oxid-console) itself, which will be continue to support the functionality via this module.

That way the new oxid core console (https://github.com/OXID-eSales/oxideshop_ce/tree/b-6.x-introduce_console-OXDEV-1580) will also support the comand from this module and so will oxrun (https://github.com/OXIDprojects/oxrun)

closes https://github.com/OXIDprojects/oxid-module-internals/issues/8