### PR TITLE
user composer package to get Namespace

### DIFF
--- a/Core/OxidComposerModulesService.php
+++ b/Core/OxidComposerModulesService.php
@@ -46,6 +46,18 @@ class OxidComposerModulesService
     }
 
     /**
+     * @param $moduleId
+     * @return bool|PackageInterface
+     */
+    public function getPackage($moduleId) {
+        $list = $this->getList();
+        if (!isset($list[$moduleId])) {
+            return false;
+        }
+        return $list[$moduleId];
+    }
+
+    /**
      * @param $metadataPath
      * @return string
      */


### PR DESCRIPTION
Improving getting the module's namespace, before that was only possible for modules if the namespasce was registered using the target module directory (but not the vendor directory) or if the composer.json file was not excluded)