### PR TITLE
fix method not found during upgrade

### DIFF
--- a/Core/ModuleExtensionCleanerDebug.php
+++ b/Core/ModuleExtensionCleanerDebug.php
@@ -118,7 +118,7 @@ class ModuleExtensionCleanerDebug extends ModuleExtensionsCleaner
      */
     protected function filterExtensionsByModule($modules, $module)
     {
-        if ($module->isMetadataVersionGreaterEqual('2.0')) {
+        if ($this->isMetadataVersionGreaterEqual($module, '2.0')) {
             $path = $module->getModuleNameSpace();
         } else {
 
@@ -149,5 +149,10 @@ class ModuleExtensionCleanerDebug extends ModuleExtensionsCleaner
         }
 
         return $filteredModules;
+    }
+
+    public function isMetadataVersionGreaterEqual($module, $sVersion)
+    {
+        return version_compare($module->getMetaDataVersion(), $sVersion) >= 0;
     }
 }

--- a/Core/ModuleExtensionCleanerDebug.php
+++ b/Core/ModuleExtensionCleanerDebug.php
@@ -119,7 +119,11 @@ class ModuleExtensionCleanerDebug extends ModuleExtensionsCleaner
     protected function filterExtensionsByModule($modules, $module)
     {
         if ($this->isMetadataVersionGreaterEqual($module, '2.0')) {
-            $path = $module->getModuleNameSpace();
+            if (!method_exists($module,"getModuleNameSpace")) {
+                $path = '';
+            } else {
+                $path = $module->getModuleNameSpace();
+            }
         } else {
 
             $modulePaths = \OxidEsales\Eshop\Core\Registry::getConfig()->getConfigParam('aModulePaths');


### PR DESCRIPTION
as the method isMetadataVersionGreaterEqual is only availible on "module" class when module internals is upgrade during the upgrade it fails to access that method