### PR TITLE
add logging to template block fixer

### DIFF
--- a/Core/ModuleStateFixer.php
+++ b/Core/ModuleStateFixer.php
@@ -635,6 +635,7 @@ class ModuleStateFixer extends ModuleInstaller
 
         if ($rowsEffected) {
             $this->needCacheClear = true;
+            $this->output->info("fixed template blocks for module " . $moduleId);
         }
     }
 


### PR DESCRIPTION
Everytime we set `needCacheClear` to `true` we log some stuff to make it clear, why we need to clear the cache for that module. I found one place where we forgot to add the logging and added that.

before:
```
[2019-06-25 09:22:30] OXID Logger.DEBUG: initial cache cleared []
[2019-06-25 09:22:30] OXID Logger.INFO: cache cleared for modulename1 []
[2019-06-25 09:22:30] OXID Logger.INFO: cache cleared for modulename2 []
[2019-06-25 09:22:30] OXID Logger.INFO: cache cleared for modulename3 []
```

after:
```
[2019-06-25 09:37:02] OXID Logger.DEBUG: initial cache cleared []
[2019-06-25 09:37:02] OXID Logger.INFO: fixed template blocks for module modulename1 []
[2019-06-25 09:37:02] OXID Logger.INFO: cache cleared for modulename1 []
[2019-06-25 09:37:02] OXID Logger.INFO: fixed template blocks for module modulename2 []
[2019-06-25 09:37:02] OXID Logger.INFO: cache cleared for modulename2 []
[2019-06-25 09:37:02] OXID Logger.INFO: fixed template blocks for module modulename3 []
[2019-06-25 09:37:02] OXID Logger.INFO: cache cleared for modulename3 []
```

---

here are the other places:
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L183-L186
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L190-L192
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L218-L221
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L225-L227
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L250-L252
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L256-L258
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L282-L285
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L288-L289
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L307-L313
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L317-L319
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L426-L427
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L447-L463
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L494-L495
https://github.com/OXIDprojects/oxid-module-internals/blob/acfd0e6334b99b02c0f6ebcb738190511e89a4ee/Core/ModuleStateFixer.php#L542-L545