### PR TITLE
_addModuleSettings: Check getShopConfVar() before getConfigParam()

### DIFF
--- a/Core/ModuleStateFixer.php
+++ b/Core/ModuleStateFixer.php
@@ -415,12 +415,18 @@ class ModuleStateFixer extends ModuleInstaller
                 $name = $setting["name"];
                 $type = $setting["type"];
 
-                if (isset($setting["value"]) && is_null($config->getConfigParam($name))){
+                // Third party modules might extend getShopConfVar() and/or getConfigParam()
+                $dbValue=$config->getShopConfVar($name,$shopId,$module);
+                if (is_null($dbValue)) {
+                    $dbValue = $config->getConfigParam($name);
+                }
+
+                if (isset($setting["value"]) && is_null($dbValue)){
                     $diff = true;
                     $value = $setting["value"];
                     $config->saveShopConfVar($type, $name, $value, $shopId, $module);
                     $this->output->debug("$moduleId: setting for '$name' fixed'");
-                } ;
+                };
             }
             if ($diff) {
                 $this->output->warning("$moduleId: settings fixed'");


### PR DESCRIPTION
Some third-party-modules (eg "dd_faq") only seem to extend getShopConfVar() but not getConfigParam(). Module Internals will not see a db-value in these cases and try to save the default-value, which will then override the actual value the module had stored somewhere.
(Module internals will always show "Fixed state" for such modules in the module list)

As workaround getShopConfVar() could be checked first and getConfigParam() can be called as fallback.