### PR TITLE
fixed bug where arrays are not null but empty, causing bad output

### DIFF
--- a/Core/ModuleStateFixer.php
+++ b/Core/ModuleStateFixer.php
@@ -368,14 +368,14 @@ class ModuleStateFixer extends ModuleInstaller
      */
     protected function diff($array1, $array2)
     {
-        if ($array1 === null) {
-            if ($array2 === null) {
+        if ($array1 === null || empty($array1)) {
+            if ($array2 === null || empty($array1)) {
                 return false; //indicate no diff
             }
             return $array2; //full array2 is new
         }
         if ($array2 === null) {
-            //indicate that diff is there  (so return a true value) but everthing should be droped
+            //indicate that diff is there  (so return a true value) but everything should be dropped
             return 'null';
         }
         $array_diff_assoc1 = @array_diff_assoc($array1, $array2);


### PR DESCRIPTION
console fix:states sometimes displayed this output:

```
/var/www/oxideshop$ vendor/bin/oxid module:fix --all
Oxid Professional Services consle  is called by vendor/bin/oxid
Oxid project root is found at /var/www/oxideshop
Loading Oxid bootstrap...
oxid bootstrap done. 
collecting comands.. 
commands collected
commands added
PHP Notice:  Array to string conversion in /var/www/oxideshop/vendor/oxid-community/moduleinternals/Core/ModuleStateFixer.php on line 373
```
