### PR TITLE
Add command to services.yaml file

### DIFF
--- a/services.yaml
+++ b/services.yaml
@@ -2,4 +2,4 @@ services:
   oxid_community.moduleinternals.module.fix.command:
     class: OxidCommunity\ModuleInternals\Command\ModuleFixCommand
     tags:
-    - { name: 'console.command' }
+      - { name: 'console.command', command: 'module:fix', description: 'Fixes modules metadata states'}


### PR DESCRIPTION
The Symfony console first tries to load the command name [from the service-definition][1], if this fails it loads the command name via the [getDefaultName() method][2], which does not work sometimes. 
We saw this error lately in our logs:

```
[file /var/www/html/vendor/symfony/console/DependencyInjection/AddConsoleCommandPass.php]
[message Uncaught Error: Call to undefined method OxidCommunity\ModuleInternals\Command\ModuleFixCommand::getDefaultName()
in /var/www/html/vendor/symfony/console/DependencyInjection/AddConsoleCommandPass.php:61
[...]
```

This broke the OXID Composer Plugin for me because it didn't install some of the modules into the `source/modules` directory anymore.

Might be related to this problem: https://stackoverflow.com/a/49943126/2123108

Looks like composer itself (and therefore the composer-plugin) uses an older version of the `symfony/console` package as you can see [here](oxideshop/vendor/composer/composer/composer.lock)

[1]: https://github.com/symfony/console/blob/v3.4.15/DependencyInjection/AddConsoleCommandPass.php#L47-L53
[2]: https://github.com/symfony/console/blob/v3.4.15/DependencyInjection/AddConsoleCommandPass.php#L61